### PR TITLE
Inject projects variable into handlers

### DIFF
--- a/internal/config/inject/projects-injector.go
+++ b/internal/config/inject/projects-injector.go
@@ -1,0 +1,41 @@
+package inject
+
+import (
+	"strings"
+
+	"github.com/VEuPathDB/util-exporter-server/internal/job"
+	"github.com/VEuPathDB/util-exporter-server/internal/wdk/site"
+	"github.com/sirupsen/logrus"
+)
+
+const projectsInjectorTarget = "<<projects>>"
+
+// NewDsUserIdInjector returns a new VariableInjector instance that will
+// replace <<projects>> variables in a command config.
+func NewProjectsInjector(
+	_ *job.Details,
+	meta *job.Metadata,
+	log *logrus.Entry,
+) VariableInjector {
+	log.Trace("inject.NewProjectsInjector")
+	return &projectsInjector{log, meta}
+}
+
+type projectsInjector struct {
+	log   *logrus.Entry
+	state *job.Metadata
+}
+
+func (injector *projectsInjector) Inject(target []string) ([]string, error) {
+	injector.log.Trace("inject.projectsInjector.Inject")
+	return simpleReplace(target, projectsInjectorTarget,
+		strings.Join(sitesToString(injector.state.Projects), ",")), nil
+}
+
+func sitesToString(sites []site.WdkSite) []string {
+	stringSites := []string{}
+	for _, site := range sites {
+		stringSites = append(stringSites, string(site))
+	}
+	return stringSites
+}

--- a/internal/config/inject/projects-injector_test.go
+++ b/internal/config/inject/projects-injector_test.go
@@ -1,0 +1,53 @@
+package inject_test
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/VEuPathDB/util-exporter-server/internal/config/inject"
+	"github.com/VEuPathDB/util-exporter-server/internal/dataset"
+	"github.com/VEuPathDB/util-exporter-server/internal/job"
+	"github.com/VEuPathDB/util-exporter-server/internal/wdk/site"
+)
+
+func TestProjectsInjector_Test(t *testing.T) {
+	Convey("Projects Injector", t, func() {
+		Convey("Single Project", func() {
+			projects := []site.WdkSite{site.VectorBase}
+			baseInfo := dataset.BaseInfo{Projects: projects}
+			metadata := job.Metadata{BaseInfo: baseInfo}
+
+			tests := [][2][]string{
+				{{"<<projects>>"}, {"VectorBase"}},
+				{{"--projects=<<projects>>"}, {"--projects=VectorBase"}},
+			}
+
+			for _, test := range tests {
+				inj := inject.NewProjectsInjector(nil, &metadata, logrus.WithField("test", true))
+				a, b := inj.Inject(test[0])
+				So(b, ShouldBeNil)
+				So(a, ShouldResemble, test[1])
+			}
+		})
+		Convey("Multiple Projects", func() {
+			projects := []site.WdkSite{site.VectorBase, site.PlasmoDB}
+			baseInfo := dataset.BaseInfo{Projects: projects}
+			metadata := job.Metadata{BaseInfo: baseInfo}
+
+			tests := [][2][]string{
+				{{"<<projects>>"}, {"VectorBase,PlasmoDB"}},
+				{{"--projects=<<projects>>"}, {"--projects=VectorBase,PlasmoDB"}},
+			}
+
+			for _, test := range tests {
+				inj := inject.NewProjectsInjector(nil, &metadata, logrus.WithField("test", true))
+				a, b := inj.Inject(test[0])
+				So(b, ShouldBeNil)
+				So(a, ShouldResemble, test[1])
+			}
+		})
+	})
+}

--- a/internal/config/injector-list.go
+++ b/internal/config/injector-list.go
@@ -29,5 +29,6 @@ func InjectorList() []InjectorProvider {
 		inject.NewTimeInjector,
 		inject.NewTimestampInjector,
 		inject.NewHandlerParamInjector,
+		inject.NewProjectsInjector,
 	}
 }

--- a/readme.adoc
+++ b/readme.adoc
@@ -326,6 +326,15 @@ The current unix timestamp in seconds.
 783647299
 ----
 
+==== `<<projects>>`
+
+A comma-separated list of project identifiers.
+
+.Example
+----
+VectorBase,PlasmoDB
+----
+
 ==== `+<<handler-params.p1>>+`
 
 Access of handler-specific parameter values from the request body of the import request.


### PR DESCRIPTION
Per discussion in service-user-dataset-import#19, we're planning to use the project identifiers wire through the API as opposed to a reference genome.

Resolves service-user-dataset-import#19