### PR TITLE
Remove quote insertion when passing to Go CLI executor

### DIFF
--- a/internal/config/inject/ds-description.go
+++ b/internal/config/inject/ds-description.go
@@ -21,6 +21,6 @@ type dsDescriptionInjector struct {
 
 func (d *dsDescriptionInjector) Inject(target []string) ([]string, error) {
 	d.log.Trace("inject.dsDescriptionInjector.Inject")
-	return forceQuotesReplace(target, dsDescriptionInjectorTarget,
+	return simpleReplace(target, dsDescriptionInjectorTarget,
 		d.state.Description), nil
 }

--- a/internal/config/inject/ds-name.go
+++ b/internal/config/inject/ds-name.go
@@ -25,6 +25,6 @@ type dsNameInjector struct {
 
 func (d *dsNameInjector) Inject(target []string) ([]string, error) {
 	d.log.Trace("inject.dsNameInjector.Inject")
-	return forceQuotesReplace(target, dsNameInjectorTarget,
+	return simpleReplace(target, dsNameInjectorTarget,
 		d.state.Name), nil
 }

--- a/internal/config/inject/ds-summary.go
+++ b/internal/config/inject/ds-summary.go
@@ -25,6 +25,6 @@ type dsSummaryInjector struct {
 
 func (d *dsSummaryInjector) Inject(target []string) ([]string, error) {
 	d.log.Trace("inject.dsSummaryInjector.Inject")
-	return forceQuotesReplace(target, dsSummaryInjectorTarget,
+	return simpleReplace(target, dsSummaryInjectorTarget,
 		d.state.Summary), nil
 }


### PR DESCRIPTION
Go is automatically quoting strings that are passed as args when calling exec.Command. By forcing quotes in the injection code, we end up double quoting and we have quotes in IRODS.
```
gene-list-handler_1  | time="2022-08-03 18:16:59.685677" level=debug msg="['has a space', '', '""', '354383910', 'html.html', 'direct-upload', 'PlasmoDB', 'GenesByTaxon_Summary.txt']
```